### PR TITLE
Bugfix/apt get

### DIFF
--- a/init_SM.sh
+++ b/init_SM.sh
@@ -4,10 +4,10 @@
 
 
 # Check for available updates
-sudo apt update
+sudo apt-get update
 
 # Make sure the certificate handler and curl utilities are installed
-sudo apt install ca-certificates curl -y
+sudo apt-get install ca-certificates curl -y
 
 # Modern install method: add Docker's official GPG key:
 sudo install -m 0755 -d /etc/apt/keyrings
@@ -19,10 +19,10 @@ echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
   $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-sudo apt update
+sudo apt-get update
 
 # Install the latest version of some Docker packages
-sudo apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
 
 
 # Lets the user account run Docker without elevated privileges

--- a/init_SM.sh
+++ b/init_SM.sh
@@ -4,10 +4,10 @@
 
 
 # Check for available updates
-sudo apt-get update
+sudo apt-get -qq update
 
 # Make sure the certificate handler and curl utilities are installed
-sudo apt-get install ca-certificates curl -y
+sudo apt-get -qq install ca-certificates curl -y
 
 # Modern install method: add Docker's official GPG key:
 sudo install -m 0755 -d /etc/apt/keyrings
@@ -19,7 +19,7 @@ echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
   $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-sudo apt-get update
+sudo apt-get -qq update
 
 # Install the latest version of some Docker packages
 sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y

--- a/init_SM.sh
+++ b/init_SM.sh
@@ -7,7 +7,7 @@
 sudo apt-get -qq update
 
 # Make sure the certificate handler and curl utilities are installed
-sudo apt-get -q install ca-certificates curl -y
+sudo apt-get -qq install ca-certificates curl -y
 
 # Modern install method: add Docker's official GPG key:
 sudo install -m 0755 -d /etc/apt/keyrings
@@ -22,7 +22,7 @@ echo \
 sudo apt-get -qq update
 
 # Install the latest version of some Docker packages
-sudo apt-get -q install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+sudo apt-get -qq install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
 
 
 # Lets the user account run Docker without elevated privileges
@@ -34,5 +34,11 @@ sudo systemctl start docker
 # Sets Docker to run in the background whenever the board starts up
 sudo systemctl enable docker
 
-# Note: the user now needs to log out and in again (or reboot) 
+# Test the install by printing the version numbers
+echo -n "        Installed "
+docker -v
+echo -n "        Installed "
+docker compose version
+
+# Note: the user now needs to log out and in again (or reboot)
 # for the permission changes above to take effect

--- a/init_SM.sh
+++ b/init_SM.sh
@@ -7,7 +7,7 @@
 sudo apt-get -qq update
 
 # Make sure the certificate handler and curl utilities are installed
-sudo apt-get -qq -o=Dpkg::Use-Pty=0 install ca-certificates curl -y
+sudo apt-get -q install ca-certificates curl -y
 
 # Modern install method: add Docker's official GPG key:
 sudo install -m 0755 -d /etc/apt/keyrings
@@ -22,7 +22,7 @@ echo \
 sudo apt-get -qq update
 
 # Install the latest version of some Docker packages
-sudo apt-get -qq install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+sudo apt-get -q install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
 
 
 # Lets the user account run Docker without elevated privileges

--- a/init_SM.sh
+++ b/init_SM.sh
@@ -22,10 +22,12 @@ echo \
 sudo apt-get -qq update
 
 # Install the latest version of some Docker packages
+echo -n "        Installing docker packages..."
 sudo apt-get -qq install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
 
 
 # Lets the user account run Docker without elevated privileges
+echo -n "        Adding current user to docker user group..."
 sudo usermod -a -G docker $USER
 
 # Starts Docker running in the background
@@ -42,3 +44,4 @@ docker compose version
 
 # Note: the user now needs to log out and in again (or reboot)
 # for the permission changes above to take effect
+echo -n "        User permissions will be applied after the next reboot"

--- a/init_SM.sh
+++ b/init_SM.sh
@@ -7,7 +7,7 @@
 sudo apt-get -qq update
 
 # Make sure the certificate handler and curl utilities are installed
-sudo apt-get -qq install ca-certificates curl -y
+sudo apt-get -qq -o=Dpkg::Use-Pty=0 install ca-certificates curl -y
 
 # Modern install method: add Docker's official GPG key:
 sudo install -m 0755 -d /etc/apt/keyrings
@@ -22,7 +22,7 @@ echo \
 sudo apt-get -qq update
 
 # Install the latest version of some Docker packages
-sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+sudo apt-get -qq install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
 
 
 # Lets the user account run Docker without elevated privileges

--- a/init_SM.sh
+++ b/init_SM.sh
@@ -31,6 +31,7 @@ echo "        Adding current user to docker user group..."
 sudo usermod -a -G docker $USER
 
 # Starts Docker running in the background
+echo "        Starting docker now and on every boot..."
 sudo systemctl start docker
 
 # Sets Docker to run in the background whenever the board starts up

--- a/init_SM.sh
+++ b/init_SM.sh
@@ -22,12 +22,12 @@ echo \
 sudo apt-get -qq update
 
 # Install the latest version of some Docker packages
-echo -n "        Installing docker packages..."
+echo "        Installing docker packages..."
 sudo apt-get -qq install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
 
 
 # Lets the user account run Docker without elevated privileges
-echo -n "        Adding current user to docker user group..."
+echo "        Adding current user to docker user group..."
 sudo usermod -a -G docker $USER
 
 # Starts Docker running in the background
@@ -44,4 +44,4 @@ docker compose version
 
 # Note: the user now needs to log out and in again (or reboot)
 # for the permission changes above to take effect
-echo -n "        User permissions will be applied after the next reboot"
+echo "        User permissions will be applied after the next reboot"


### PR DESCRIPTION
Switch from using `apt` to `apt-get -qq` for installations. Fixes #4 

Apparently apt-get is preferred for scripting. 

Also clean up the terminal output.
The very quiet `-qq` option should suppress all output but errors, but doesn't contol the downstream utilities (dpkg etc), so there's still plenty of output. 